### PR TITLE
add shebang to shannon.py

### DIFF
--- a/shannon.py
+++ b/shannon.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python2
+
 import time
 import sys
 import re


### PR DESCRIPTION
add shebang to allow shannon.py to be executable (imp for bioconda recipe). We currently included this as a patch in the recipe, but this change would eliminate the need for that patch. thx!